### PR TITLE
Add: brotli, http2 and zlib support

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -30,6 +30,18 @@ jobs:
       run: |
         docker run -t macbre/curl-http3 curl --version
 
+    - name: Is brotli supported?
+      run: |
+        docker run --rm macbre/curl-http3 curl -sIL https://httpbin.org/brotli | grep -i 'content-encoding: br'
+
+    - name: Is gzip supported?
+      run: |
+        docker run --rm macbre/curl-http3 curl -sIL https://httpbin.org/gzip | grep -i 'content-encoding: gzip'
+
+    - name: Is http/2 supported?
+      run: |
+        docker run --rm macbre/curl-http3 curl -sIL https://httpbin.org/get | grep -i 'HTTP/2'
+
     - name: Is http/3 supported?
       run: |
         docker run --rm macbre/curl-http3 curl -sIL https://blog.cloudflare.com --http3 -H 'user-agent: mozilla' | grep 'HTTP/3'

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,14 @@ WORKDIR /opt
 RUN apk add --no-cache \
   autoconf \
   automake \
+  brotli-dev \
   build-base \
   cmake \
   git \
   libtool \
+  nghttp2-dev \
   pkgconfig \
   wget \
-  brotli-dev \
-  nghttp2-dev \
   zlib-dev
 
 # set up our home directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,10 @@ RUN apk add --no-cache \
   git \
   libtool \
   pkgconfig \
-  wget
+  wget \
+  brotli-dev \
+  nghttp2-dev \
+  zlib-dev
 
 # set up our home directory
 RUN mkdir -p /root
@@ -51,9 +54,17 @@ RUN \
   git clone -b ${CURL_VERSION} --depth 1 --single-branch https://github.com/curl/curl && \
   cd curl && \
   autoreconf -fi && \
-  ./configure LDFLAGS="-Wl,-rpath,/opt/quiche/target/release" --with-openssl=/opt/quiche/quiche/deps/boringssl/src --with-quiche=/opt/quiche/target/release && \
+  ./configure LDFLAGS="-Wl,-rpath,/opt/quiche/target/release" \
+    --with-brotli \
+    --with-nghttp2 \
+    --with-openssl=/opt/quiche/quiche/deps/boringssl/src \
+    --with-quiche=/opt/quiche/target/release \
+    --with-zlib && \
   make && \
   make install
+
+# so that we know what to copy over from the "base" stage
+RUN ldd $(which curl)
 
 # make our resulting image way smaller
 # from 2.85GB to 44.9MB
@@ -68,6 +79,10 @@ ENV QUICHE_VERSION $QUICHE_VERSION
 COPY --from=base /usr/local/bin/curl /usr/local/bin/curl
 COPY --from=base /usr/local/lib/libcurl.so.4 /usr/local/lib/libcurl.so.4
 COPY --from=base /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+COPY --from=base /usr/lib/libnghttp2.so.14 /usr/lib/libnghttp2.so.14
+COPY --from=base /usr/lib/libbrotlidec.so.1 /usr/lib/libbrotlidec.so.1
+COPY --from=base /lib/libz.so.1 /lib/libz.so.1
+COPY --from=base /usr/lib/libbrotlicommon.so.1 /usr/lib/libbrotlicommon.so.1
 
 # we do not need root anymore
 USER nobody

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 A custom `curl` build with `BoringSSL` and http3 support via `quiche` in **under 50MB container image**.
 
 ```
-curl 7.84.0-DEV (x86_64-pc-linux-musl) libcurl/7.84.0-DEV BoringSSL quiche/0.14.0
+curl 7.84.0-DEV (x86_64-pc-linux-musl) libcurl/7.84.0-DEV BoringSSL zlib/1.2.12 brotli/1.0.9 nghttp2/1.43.0 quiche/0.14.0
 Release-Date: [unreleased]
-Protocols: dict file ftp ftps gopher gophers http https imap imaps mqtt pop3 pop3s rtsp smb smbs smtp smtps telnet tftp 
-Features: alt-svc AsynchDNS HSTS HTTP3 HTTPS-proxy IPv6 Largefile NTLM NTLM_WB SSL threadsafe UnixSockets
+Protocols: dict file ftp ftps gopher gophers http https imap imaps mqtt pop3 pop3s rtsp smb smbs smtp smtps telnet tftp
+Features: alt-svc AsynchDNS brotli HSTS HTTP2 HTTP3 HTTPS-proxy IPv6 Largefile libz NTLM NTLM_WB SSL threadsafe UnixSockets
 ```
 
 ## Usage


### PR DESCRIPTION
```
$ docker run --rm docker.io/macbre/curl3 curl --version
curl 7.84.0-DEV (x86_64-pc-linux-musl) libcurl/7.84.0-DEV BoringSSL zlib/1.2.12 brotli/1.0.9 nghttp2/1.43.0 quiche/0.14.0
Release-Date: [unreleased]
Protocols: dict file ftp ftps gopher gophers http https imap imaps mqtt pop3 pop3s rtsp smb smbs smtp smtps telnet tftp 
Features: alt-svc AsynchDNS brotli HSTS HTTP2 HTTP3 HTTPS-proxy IPv6 Largefile libz NTLM NTLM_WB SSL threadsafe UnixSockets
```

Resolves #2 